### PR TITLE
✨ Fail-on-workload-error flag + resilient post lifecycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,11 +121,15 @@ git commit -m "emoji subject"
 
 ### GitHub Actions Lifecycle (Init Action)
 
-1. `main.ts` runs PRE user workload → deploys infrastructure, saves state via `saveState()`
-2. User workload runs
-3. `post.ts` runs POST → collects metrics, uploads artifacts, cleanup
+1. `main.ts` runs first → deploys infrastructure, runs workload containers, waits for them
+2. `post.ts` runs at job end (always) → best-effort collects artifacts, tears down, uploads
 
-State passed via `saveState()`/`getState()`: cwd, workload name, PR number, start timestamp
+State passed via `saveState()`/`getState()`: cwd, workload name, PR number, commit, start/finish timestamps, failure reason (`failed`).
+
+**Lifecycle resilience contract:**
+
+- `main` owns the definitive pass/fail decision. Cluster deploy failure fails the run unconditionally; a workload failure fails the run only when `fail_on_workload_error: true`.
+- `post` is best-effort diagnostics + cleanup and never decides pass/fail. It discovers what exists (e.g. probes for the Prometheus container) instead of assuming, degrades each collector to an empty artifact when its source is absent, guarantees teardown via `finally`, and never crashes. Whether a report runs on a failed init is workflow orchestration (`needs:`/`if:`, or `workflow_run.conclusion`), not an action input.
 
 ### Metrics Collection
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Your SDK should handle these scenarios gracefully. The metrics show how well it 
 | `github_token`              | no       | —             | GitHub token for API access                                                          |
 | `github_issue`              | no       | auto-detected | Pull request number                                                                  |
 | `workload_duration`         | no       | `60`          | Duration of the workload in seconds                                                  |
+| `fail_on_workload_error`    | no       | `false`       | Fail the whole run if any workload container exits non-zero or times out              |
 | `workload_current_ref`      | no       | `current`     | Git ref for current version (used as `ref` label in metrics)                         |
 | `workload_current_command`  | no       | `""`          | Command arguments for current workload                                               |
 | `workload_baseline_image`   | no       | —             | Docker image for baseline workload (if not provided, baseline comparison is skipped) |
@@ -112,6 +113,56 @@ profile to run a smaller **2-node** cluster — cheaper and faster to start:
 A 2-node cluster suits quick smoke runs more than strict SLO gating: chaos
 faults remove a larger fraction of the cluster (stopping one node drops 50% of
 compute instead of 20%), so latency/availability swings are wider by design.
+
+### Fail fast on workload errors
+
+By default a workload container that exits non-zero (or times out) is recorded but
+does **not** fail the run — metrics are still collected and a report is produced.
+Set `fail_on_workload_error: true` to turn any such failure into a hard failure of
+the whole run (useful for simple pass/fail smoke tests):
+
+```yaml
+- uses: ydb-platform/ydb-slo-action/init@v2
+  with:
+    workload_name: topics-smoke
+    workload_current_image: my-topics-workload:current
+    fail_on_workload_error: true
+    disable_compose_profiles: telemetry,chaos # no metrics needed for a smoke test
+```
+
+The flag only fails the run. Whether a **report** is produced on a failed run is
+decided by your workflow, not the action. In a single workflow, gate the report job:
+
+```yaml
+report:
+  needs: test # skipped when `test` fails -> no report on failure
+  # if: ${{ !cancelled() }}   # alternatively: always report (failure card on failure)
+```
+
+For pull requests from forks (where the `pull_request` token is read-only and
+cannot post comments), report from a separate workflow triggered by `workflow_run`,
+which runs in the base repo with write permissions:
+
+```yaml
+# .github/workflows/slo-report.yml
+on:
+  workflow_run:
+    workflows: ["SLO Test"] # = name: of the SLO workflow
+    types: [completed]
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - uses: ydb-platform/ydb-slo-action/report@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_run_id: ${{ github.event.workflow_run.id }}
+```
 
 ### Init Action Outputs
 

--- a/dist/init/main.js
+++ b/dist/init/main.js
@@ -1,9 +1,10 @@
 import {
+  extraArtifactsPath,
   getComposeProfiles,
   getContainerIp,
   getPullRequestNumber,
   waitForContainerCompletion
-} from "../main-73wr87bf.js";
+} from "../main-mmj9rtzx.js";
 import {
   debug,
   error,
@@ -12,7 +13,8 @@ import {
   info,
   saveState,
   setFailed,
-  setOutput
+  setOutput,
+  warning
 } from "../main-w8t1tja0.js";
 
 // init/main.ts
@@ -22,7 +24,7 @@ import { fileURLToPath } from "node:url";
 process.env.GITHUB_ACTION_PATH ??= fileURLToPath(new URL("../..", import.meta.url));
 async function main() {
   let cwd = path.join(process.cwd(), ".slo"), workload = getInput("workload_name") || "unspecified";
-  saveState("cwd", cwd), saveState("pull", await getPullRequestNumber()), saveState("commit", process.env.GITHUB_SHA), saveState("workload", workload), fs.mkdirSync(cwd, { recursive: !0 }), fs.mkdirSync(path.join(cwd, "extra"), { recursive: !0 }), await copyAssets(cwd);
+  saveState("cwd", cwd), saveState("pull", await getPullRequestNumber()), saveState("commit", process.env.GITHUB_SHA), saveState("workload", workload), fs.mkdirSync(cwd, { recursive: !0 }), fs.mkdirSync(extraArtifactsPath(cwd), { recursive: !0 }), await copyAssets(cwd);
   try {
     await deployInfra(cwd, workload);
   } catch (err) {
@@ -87,26 +89,26 @@ async function deployInfra(cwd, workload) {
 async function waitForWorkloads() {
   let start = /* @__PURE__ */ new Date;
   saveState("start", start.toISOString()), info(`Workloads started at ${start}`);
-  let workloadCurrentImage = getInput("workload_current_image"), workloadBaselineImage = getInput("workload_baseline_image") || "", workloadDuration = parseInt(getInput("workload_duration") || "60", 10), workloadTimeoutMs = (workloadDuration + 60) * 1000;
-  debug(`Workload configuration: duration=${workloadDuration}s, timeout=${workloadTimeoutMs}ms`);
+  let workloadCurrentImage = getInput("workload_current_image"), workloadBaselineImage = getInput("workload_baseline_image") || "", workloadDuration = parseInt(getInput("workload_duration") || "60", 10), workloadTimeoutMs = (workloadDuration + 60) * 1000, failFast = getInput("fail_on_workload_error") === "true";
+  debug(`Workload configuration: duration=${workloadDuration}s, timeout=${workloadTimeoutMs}ms, failFast=${failFast}`);
   let workloadsToWait = [];
   if (workloadCurrentImage)
     workloadsToWait.push({ name: "current", container: "ydb-workload-current" });
   if (workloadBaselineImage)
     workloadsToWait.push({ name: "baseline", container: "ydb-workload-baseline" });
+  let failures = [];
   if (workloadsToWait.length > 0) {
-    info(`Waiting for ${workloadsToWait.length} workload(s) to complete...`), info(`  - ${workloadsToWait.map((w) => w.name).join(", ")}`), info(`  - Timeout: ${workloadTimeoutMs / 1000}s (workload duration + 60s buffer)`);
-    try {
-      await Promise.all(workloadsToWait.map((w) => waitForContainerCompletion({
-        container: w.container,
-        timeoutMs: workloadTimeoutMs
-      }))), info("All workloads completed successfully");
-    } catch (err) {
-      error(`Workload failed: ${err}`);
-    }
+    if (info(`Waiting for ${workloadsToWait.length} workload(s) to complete...`), info(`  - ${workloadsToWait.map((w) => w.name).join(", ")}`), info(`  - Timeout: ${workloadTimeoutMs / 1000}s (workload duration + 60s buffer)`), (await Promise.allSettled(workloadsToWait.map((w) => waitForContainerCompletion({ container: w.container, timeoutMs: workloadTimeoutMs })))).forEach((result, i) => {
+      if (result.status === "rejected") {
+        let name = workloadsToWait[i].name;
+        failures.push(`${name}: ${result.reason}`), warning(`Workload '${name}' failed: ${result.reason}`);
+      }
+    }), failures.length === 0)
+      info("All workloads completed successfully");
   }
   let finish = /* @__PURE__ */ new Date;
-  saveState("finish", finish.toISOString()), info(`Workloads finished at ${finish}`);
+  if (saveState("finish", finish.toISOString()), info(`Workloads finished at ${finish}`), failFast && failures.length > 0)
+    throw Error(`Workload(s) failed: ${failures.join("; ")}`);
 }
 await main();
 process.exit(0);

--- a/dist/init/post.js
+++ b/dist/init/post.js
@@ -1,9 +1,10 @@
 import {
   collectComposeLogs,
+  collectExtraArtifacts,
   getComposeProfiles,
   getContainerIp,
   uploadArtifacts
-} from "../main-73wr87bf.js";
+} from "../main-mmj9rtzx.js";
 import {
   analyzeWorkload,
   formatChangeCell,
@@ -323,50 +324,60 @@ async function writeJobSummary(analysis) {
 
 // init/post.ts
 process.env.GITHUB_ACTION_PATH ??= fileURLToPath(new URL("../..", import.meta.url));
-async function walkExtraFiles(dir) {
-  let entries = await fs2.readdir(dir, { withFileTypes: true });
-  let files = [];
-  for (let entry of entries) {
-    let fullPath = path2.join(dir, entry.name);
-    if (entry.isDirectory())
-      files.push(...await walkExtraFiles(fullPath));
-    else if (entry.isFile())
-      files.push(fullPath);
-  }
-  return files;
-}
-async function collectExtraArtifacts(cwd) {
-  let extraDir = path2.join(cwd, "extra");
-  try {
-    await fs2.access(extraDir);
-  } catch {
-    return [];
-  }
-  let files = await walkExtraFiles(extraDir);
-  if (files.length > 0)
-    info(`Found ${files.length} extra artifact file(s) in ${extraDir}`);
-  return files;
-}
 async function post() {
-  let cwd = getState("cwd"), workload = getState("workload"), logsPath = path2.join(cwd, `${workload}-logs.txt`), alertsPath = path2.join(cwd, `${workload}-alerts.jsonl`), metricsPath = path2.join(cwd, `${workload}-metrics.jsonl`), metadataPath = path2.join(cwd, `${workload}-metadata.json`), logsContent = await collectLogs();
-  await fs2.writeFile(logsPath, logsContent, { encoding: "utf-8" });
-  let alertsContent = await collectAlerts();
-  await fs2.writeFile(alertsPath, alertsContent, { encoding: "utf-8" });
-  let metricsContent = await collectMetrics();
-  await fs2.writeFile(metricsPath, metricsContent, { encoding: "utf-8" });
-  let metadataContent = await collectMetadata();
-  await fs2.writeFile(metadataPath, metadataContent, { encoding: "utf-8" });
-  let profiles = await getComposeProfiles(cwd);
-  if (await exec("docker", ["compose", "-f", "compose.yml", "down"], {
-    cwd: path2.resolve(process.env.GITHUB_ACTION_PATH, "deploy"),
-    env: {
-      ...process.env,
-      COMPOSE_PROFILES: profiles.join(",")
-    }
-  }), await uploadArtifacts(workload, [logsPath, alertsPath, metricsPath, metadataPath, ...await collectExtraArtifacts(cwd)], cwd), getState("failed"))
-    await writeFailedSummary();
-  else
-    await writeWorkloadSummary(metricsContent);
+  let cwd = getState("cwd"), workload = getState("workload"), logsPath = path2.join(cwd, `${workload}-logs.txt`), alertsPath = path2.join(cwd, `${workload}-alerts.jsonl`), metricsPath = path2.join(cwd, `${workload}-metrics.jsonl`), metadataPath = path2.join(cwd, `${workload}-metadata.json`), metricsContent = "", extraArtifactPaths = [];
+  try {
+    await persist(logsPath, collectLogs), await persist(alertsPath, collectAlerts), metricsContent = await persist(metricsPath, collectMetrics), await persist(metadataPath, collectMetadata);
+  } finally {
+    await teardown(cwd);
+  }
+  try {
+    extraArtifactPaths = await collectExtraArtifacts(cwd);
+  } catch (err) {
+    warning(`Failed to collect extra artifacts: ${err}`);
+  }
+  try {
+    await uploadArtifacts(workload, [logsPath, alertsPath, metricsPath, metadataPath, ...extraArtifactPaths], cwd);
+  } catch (err) {
+    warning(`Artifact upload failed: ${err}`);
+  }
+  try {
+    if (getState("failed"))
+      await writeFailedSummary();
+    else
+      await writeWorkloadSummary(metricsContent);
+  } catch (err) {
+    warning(`Writing job summary failed: ${err}`);
+  }
+}
+async function persist(filePath, collect) {
+  let content = "";
+  try {
+    content = await collect();
+  } catch (err) {
+    warning(`Failed to collect ${path2.basename(filePath)}: ${err}`);
+  }
+  try {
+    await fs2.writeFile(filePath, content, { encoding: "utf-8" });
+  } catch (err) {
+    warning(`Failed to write ${path2.basename(filePath)}: ${err}`);
+  }
+  return content;
+}
+async function teardown(cwd) {
+  info("Tearing down infrastructure...");
+  try {
+    let profiles = await getComposeProfiles(cwd, getInput("disable_compose_profiles").split(","));
+    await exec("docker", ["compose", "-f", "compose.yml", "down"], {
+      cwd: path2.resolve(process.env.GITHUB_ACTION_PATH, "deploy"),
+      env: {
+        ...process.env,
+        COMPOSE_PROFILES: profiles.join(",")
+      }
+    });
+  } catch (err) {
+    warning(`Teardown (docker compose down) failed: ${err}`);
+  }
 }
 async function collectLogs() {
   info("Collecting logs...");
@@ -374,24 +385,33 @@ async function collectLogs() {
   return await collectComposeLogs(cwd, profiles);
 }
 async function collectAlerts() {
-  if (info("Collecting alerts from Prometheus..."), !getState("start") || !getState("finish"))
-    return "";
-  let start = new Date(getState("start")), finish = getState("finish") ? new Date(getState("finish")) : /* @__PURE__ */ new Date, prometheusIp = await getContainerIp("ydb-prometheus"), prometheusUrl = prometheusIp ? `http://${prometheusIp}:9090` : "http://prometheus:9090";
-  return debug(`Prometheus URL for alerts: ${prometheusUrl}`), (await collectAlertsFromPrometheus(prometheusUrl, start, finish)).map((a) => JSON.stringify(a)).join(`
+  info("Collecting alerts from Prometheus...");
+  let start = getState("start"), finish = getState("finish"), prometheusIp = await getContainerIp("ydb-prometheus");
+  if (!prometheusIp || !start || !finish)
+    return info("Skipping alerts: Prometheus is not available or no time window exists"), "";
+  let prometheusUrl = `http://${prometheusIp}:9090`;
+  debug(`Prometheus URL for alerts: ${prometheusUrl}`);
+  try {
+    return (await collectAlertsFromPrometheus(prometheusUrl, new Date(start), new Date(finish))).map((a) => JSON.stringify(a)).join(`
 `);
+  } catch (err) {
+    return warning(`Failed to collect alerts: ${err}`), "";
+  }
 }
 async function collectMetrics() {
-  if (info("Collecting metrics..."), !getState("start") || !getState("finish"))
-    return "";
-  let start = new Date(getState("start")), finish = getState("finish") ? new Date(getState("finish")) : /* @__PURE__ */ new Date, prometheusIp = await getContainerIp("ydb-prometheus"), prometheusUrl = prometheusIp ? `http://${prometheusIp}:9090` : "http://prometheus:9090";
+  info("Collecting metrics...");
+  let start = getState("start"), finish = getState("finish"), prometheusIp = await getContainerIp("ydb-prometheus");
+  if (!prometheusIp || !start || !finish)
+    return info("Skipping metrics: Prometheus is not available or no time window exists"), "";
+  let prometheusUrl = `http://${prometheusIp}:9090`;
   debug(`Prometheus URL: ${prometheusUrl}`);
   let config = await loadMetricConfig(getInput("metrics_yaml"), getInput("metrics_yaml_path"));
-  return (await collectMetricsFromPrometheus(prometheusUrl, start, finish, config)).map((m) => JSON.stringify(m)).join(`
+  return (await collectMetricsFromPrometheus(prometheusUrl, new Date(start), new Date(finish), config)).map((m) => JSON.stringify(m)).join(`
 `);
 }
 async function collectMetadata() {
   info("Saving metadata...");
-  let pull = getState("pull"), commit = getState("commit"), start = new Date(getState("start")), finish = getState("finish") ? new Date(getState("finish")) : /* @__PURE__ */ new Date, failed = getState("failed"), duration = finish.getTime() - start.getTime(), workload = getState("workload"), workload_current_ref = getInput("workload_current_ref"), workload_baseline_ref = getInput("workload_baseline_ref");
+  let pull = getState("pull"), commit = getState("commit"), failed = getState("failed"), startState = getState("start"), finishState = getState("finish"), start = startState ? new Date(startState) : void 0, finish = finishState ? new Date(finishState) : void 0, workload = getState("workload"), workload_current_ref = getInput("workload_current_ref"), workload_baseline_ref = getInput("workload_baseline_ref");
   return JSON.stringify({
     pull,
     commit,
@@ -403,11 +423,11 @@ async function collectMetadata() {
     workload,
     workload_current_ref,
     workload_baseline_ref,
-    start_time: start.toISOString(),
-    start_epoch_ms: start.getTime(),
-    finish_time: finish.toISOString(),
-    finish_epoch_ms: finish.getTime(),
-    duration_ms: duration
+    start_time: start?.toISOString(),
+    start_epoch_ms: start?.getTime(),
+    finish_time: finish?.toISOString(),
+    finish_epoch_ms: finish?.getTime(),
+    duration_ms: start && finish ? finish.getTime() - start.getTime() : void 0
   });
 }
 async function writeWorkloadSummary(metricsContent) {
@@ -417,9 +437,7 @@ async function writeWorkloadSummary(metricsContent) {
   await writeJobSummary(analysis);
 }
 async function writeFailedSummary() {
-  let cwd = getState("cwd"), workload = getState("workload");
-  summary.addHeading(`Failed ${workload}.`);
-  let workloadLogs = await collectComposeLogs(cwd, ["workload-current", "workload-baseline"]);
-  summary.addCodeBlock(workloadLogs), await summary.write();
+  let workload = getState("workload"), failed = getState("failed");
+  summary.addHeading(`Failed ${workload} (${failed || "unknown"}).`), summary.addRaw(`See the \`${workload}-logs.txt\` artifact attached to this run for full logs.`, !0), await summary.write();
 }
 post();

--- a/dist/main-mmj9rtzx.js
+++ b/dist/main-mmj9rtzx.js
@@ -165,4 +165,35 @@ async function uploadArtifacts(name, artifacts, cwd) {
   }
 }
 
-export { getContainerIp, collectComposeLogs, getComposeProfiles, waitForContainerCompletion, getPullRequestNumber, uploadArtifacts };
+// init/lib/artifacts.ts
+import * as fs2 from "node:fs/promises";
+import * as path from "node:path";
+var EXTRA_ARTIFACTS_DIR = "extra";
+function extraArtifactsPath(cwd) {
+  return path.join(cwd, EXTRA_ARTIFACTS_DIR);
+}
+async function walkFiles(dir) {
+  let entries = await fs2.readdir(dir, { withFileTypes: !0 }), files = [];
+  for (let entry of entries) {
+    let fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory())
+      files.push(...await walkFiles(fullPath));
+    else if (entry.isFile())
+      files.push(fullPath);
+  }
+  return files;
+}
+async function collectExtraArtifacts(cwd) {
+  let extraDir = extraArtifactsPath(cwd);
+  try {
+    await fs2.access(extraDir);
+  } catch {
+    return [];
+  }
+  let files = await walkFiles(extraDir);
+  if (files.length > 0)
+    info(`Found ${files.length} extra artifact file(s) in ${extraDir}`);
+  return files;
+}
+
+export { getContainerIp, collectComposeLogs, getComposeProfiles, waitForContainerCompletion, getPullRequestNumber, uploadArtifacts, extraArtifactsPath, collectExtraArtifacts };

--- a/docs/superpowers/specs/2026-06-18-fail-on-workload-error-design.md
+++ b/docs/superpowers/specs/2026-06-18-fail-on-workload-error-design.md
@@ -1,0 +1,340 @@
+# Fail-on-workload-error & robust main↔post lifecycle
+
+- **Date:** 2026-06-18
+- **Status:** Approved (design)
+- **Action:** `init`
+- **Branch:** `feat/fail-on-workload-error` (off `v2`, PR back into `v2`)
+
+## Background
+
+The `init` action has two lifecycle entry points: `main.ts` deploys the YDB
+cluster and runs workload containers; `post.ts` runs at the end of the job
+(always, even on failure) to collect artifacts, tear down infrastructure, and
+write a job summary. State crosses the boundary via `saveState()`/`getState()`.
+
+Two problems motivate this work.
+
+### 1. A failed workload is silently swallowed
+
+`waitForWorkloads()` (`init/main.ts:119-163`) awaits `Promise.all` over
+`waitForContainerCompletion()` calls. `waitForContainerCompletion`
+(`init/lib/docker.ts:216-281`) correctly throws when a container exits non-zero
+or times out — but the caller's `catch` (`init/main.ts:155-157`) only logs the
+error. It never sets `failed='workload'` and never exits non-zero. As a result
+the run **always** proceeds to metric collection and reporting regardless of
+whether the workload crashed. The `saveState('failed','workload')` path at
+`init/main.ts:36-40` is effectively dead code.
+
+A future "topics" workload needs the opposite: a simple pass/fail smoke test
+where a crashed workload fails the whole run instead of silently producing a
+green result. ("No metrics, no report" in that scenario is a consequence of
+disabling telemetry and of workflow-level report gating — both orthogonal to
+this flag, see Feature A and Rollout.)
+
+### 2. `post` assumes every component is present and has no error boundary
+
+`post()` (`init/post.ts:18-55`) runs each collection step as if everything it
+deployed is present and healthy, and it has no top-level error boundary
+(`post()` is invoked at `init/post.ts:178` with no surrounding `try`). So *any*
+absent or unhealthy component — a disabled compose profile, a missing container,
+an unhealthy service, a network blip — can turn a collection step into an
+unhandled rejection that skips teardown (`docker compose down`) and artifact
+upload, leaking containers.
+
+The instance that crashes today is telemetry. With `disable_compose_profiles:
+telemetry` there is no `ydb-prometheus` container, so:
+
+- `getContainerIp('ydb-prometheus')` returns `null` and the code falls back to
+  the unresolvable `http://prometheus:9090`.
+- `collectAlertsFromPrometheus` (`init/lib/alerts.ts:11-40`) has **no** try/catch
+  around its `queryRange` fetch, and `collectAlerts` (`init/post.ts:66-83`) does
+  not wrap it either, so the alerts query throws and crashes `post()`. (Metrics
+  are softer: `collectMetricsFromPrometheus` swallows per-metric errors and
+  returns `[]`.)
+
+Telemetry is only the example that breaks first. The underlying problem is that
+`post` is not resilient to any component being absent — the fix must be general,
+not a telemetry special-case.
+
+## Goals
+
+- Add an opt-in `fail_on_workload_error` input (default `false`) that fails the
+  whole run when a workload container exits non-zero or times out.
+- Guarantee the cluster-failure path fails the run **unconditionally**,
+  independent of `fail_on_workload_error`.
+- Make `post` a pure best-effort diagnostic collector: it collects everything
+  available, always tears down, always uploads, and never crashes — regardless
+  of what failed.
+- Keep existing SLO comparison runs behaving exactly as today by default.
+
+## Non-goals
+
+- Improving *why* the cluster sometimes fails to start, or the readiness check
+  logic itself (`check-readiness.sh`). Diagnosis is out of scope; this work only
+  guarantees the failure is surfaced and diagnostic artifacts are captured.
+- A unified "smoke vs SLO mode" abstraction. The flags stay orthogonal and
+  composable (`fail_on_workload_error` + `disable_compose_profiles`).
+- Per-workload (current vs baseline) failure control. Single global flag.
+- Changes to the `report` action beyond what it already handles
+  (`report/main.ts:66` already renders a clean failure card from `meta.failed`).
+- An input controlling whether `report` runs on a failed `init`. That is
+  workflow orchestration (`needs:`/`if:`, or `workflow_run.conclusion` for the
+  cross-workflow fork pattern), not an `init`/`report` input — see Rollout.
+
+## Design principle
+
+> `main` owns the definitive pass/fail decision. `post` is best-effort
+> diagnostics + cleanup, and never decides pass/fail.
+
+`post` skips a given artifact only when its source is genuinely unavailable
+(the component was not deployed, or there is no time window) — never as a
+reaction to failure, and never via an enumerated list of special cases. This is
+what lets a failed run still produce "artifacts as usual" for diagnosis.
+
+## State contract (main → post)
+
+`main` records what it did; `post` acts only on what `main` recorded. **No new
+state keys are introduced** — the existing contract is sufficient:
+
+| Key        | Values                          | Written by                  | Meaning |
+|------------|---------------------------------|-----------------------------|---------|
+| `cwd`      | path                            | `main` (start)              | `.slo` working dir |
+| `workload` | string                          | `main` (start)              | artifact name prefix |
+| `pull`     | number                          | `main` (start)              | PR number |
+| `commit`   | sha                             | `main` (start)              | commit |
+| `start`    | ISO string                      | `main` (`waitForWorkloads`) | workload window start |
+| `finish`   | ISO string                      | `main` (`waitForWorkloads`) | workload window end |
+| `failed`   | `'' \| 'cluster' \| 'workload'` | `main`                      | failure reason; now `'workload'` is reachable |
+
+The only behavioral change to the contract is that `failed='workload'` becomes
+reachable (Feature A).
+
+### `post` discovers what exists; it is never told
+
+`post` does **not** rely on state to know which components were deployed. Each
+collector discovers its source at runtime and degrades on its own (consistent
+with the project's "settle via discovery" direction). No flag enumerates which
+profiles are on. Concretely for the telemetry case, the metrics/alerts collector
+reuses the `getContainerIp('ydb-prometheus')` call it already makes — collection
+runs before `docker compose down`, so a non-empty IP means Prometheus is
+queryable and `null`/empty means it is absent — and the broken fallback to
+`http://prometheus:9090` (`init/post.ts:77,96`) is dropped. The same
+discover-or-skip shape applies to any source, not just Prometheus.
+
+## Feature A — `fail_on_workload_error`
+
+### Interface (`init/action.yml`)
+
+```yaml
+fail_on_workload_error:
+  description: "Fail the whole run if any workload container exits non-zero or
+    times out."
+  required: false
+  default: "false"
+```
+
+Parsed with the existing idiom `getInput('fail_on_workload_error') === 'true'`
+(mirrors `report/main.ts:31`).
+
+### Behavior (`init/main.ts` `waitForWorkloads`)
+
+- Replace `Promise.all` with `Promise.allSettled`. This also fixes a latent bug:
+  `Promise.all` rejects on the first failure, so today the default path truncates
+  the metric window while the other workload is still running. `allSettled` waits
+  for every workload to finish its window.
+- Save `finish` **before** any throw, so `post` always has a valid window for
+  diagnostic metrics even on a fail-mode crash.
+- After settling, collect the rejected results:
+  - If there are failures and `fail_on_workload_error` is `true`: `throw` an
+    aggregated error. The existing `main()` catch (`init/main.ts:34-40`) sets
+    `failed='workload'`, logs, and `exit(1)`.
+  - Otherwise: emit a `warning()` per failed workload and continue. Metrics and
+    report are still produced (current behavior preserved).
+
+### Reporting on failure is workflow orchestration, not a flag
+
+`fail_on_workload_error` only fails the run; it does **not** itself skip metrics
+or the report. In fail mode `main` exits non-zero → the `init` step fails →
+whether a report is produced is decided by the workflow, not this action
+(`needs:`/`if:` in one workflow, `workflow_run.conclusion` across workflows — see
+Rollout). `post` still uploads `metadata` (with `failed`) and logs, so a report
+that *is* run on a failed init renders the existing failure card
+(`report/main.ts:66`) rather than crashing.
+
+## Feature B — robust `post` + cluster-failure diagnostics
+
+### Resilience is structural, not case-by-case
+
+Three layers together make `post` produce whatever it can and always clean up —
+for *any* absent or unhealthy component, not an enumerated list:
+
+**1. Per-collector isolation.** Each artifact is produced by an independent,
+self-guarding step. A step that cannot reach its source returns an empty result
+and logs why; it never throws out of itself. Today only the metrics path behaves
+this way (`collectMetricsFromPrometheus` swallows per-metric errors); the alerts
+path does not, which is the concrete crash. Every collector gets the same
+treatment, so a new source added later is resilient by the same rule.
+
+**2. Top-level error boundary + guaranteed teardown.** `post()` wraps collection
+in try/catch with `docker compose down` in `finally`, then best-effort upload
+and summary — so even an unforeseen throw cannot leak containers or skip upload:
+
+```
+async function post() {
+  try { /* collect + write all four artifacts (each guarded) */ }
+  catch (err) { warning(...) }
+  finally { /* docker compose down — ALWAYS */ }
+
+  try { /* uploadArtifacts */ } catch (err) { warning(...) }
+  try { /* failed ? failedSummary : workloadSummary */ } catch (err) { warning(...) }
+}
+post()
+```
+
+`post` never calls `setFailed`: the job's pass/fail comes from `main` (deploy /
+workload) and `report` (thresholds). A best-effort collector that flips the job
+result would mask the real cause.
+
+**3. Discover, don't assume.** A collector that needs a component discovers it at
+runtime rather than assuming presence (see "`post` discovers what exists"). The
+telemetry case is the instance: the metrics/alerts collector keys off the
+`ydb-prometheus` IP and skips cleanly when it is empty.
+
+Result: the full four-file artifact set (`<workload>-logs.txt`, `-alerts.jsonl`,
+`-metrics.jsonl`, `-metadata.json`) is always written and uploaded — empty where
+a source was absent — so the set stays consistent and the `report` loaders never
+break. User-provided extra artifacts from `.slo/extra/`
+(`collectExtraArtifacts`) are still appended to the upload — pre-existing
+behavior, preserved. What each step yields:
+
+- **Logs** — always (`collectComposeLogs` needs no Prometheus; the primary
+  diagnostic for a cluster failure).
+- **Metadata** — always.
+- **Metrics & alerts** — when `ydb-prometheus` is discoverable **and** a
+  `start`/`finish` window exists. `failed` does **not** gate this: diagnostic
+  metrics are still collected on a fail-mode crash if Prometheus was up.
+
+### `writeFailedSummary` points to the logs artifact (`init/post.ts:166-176`)
+
+Today it inlines workload logs via `summary.addCodeBlock` — empty for a cluster
+failure, and for a real failure potentially huge (the job summary has a 1 MiB
+limit) and redundant with the uploaded `<workload>-logs.txt` artifact. Instead,
+the failed summary is just a heading naming the failure type plus a one-line
+pointer to that artifact; logs are not duplicated into the summary:
+
+- heading: `Failed <workload> (<cluster|workload>).`
+- body: a pointer to the `<workload>-logs.txt` artifact attached to the run.
+
+Full per-failure-type logs still reach the artifact: `collectLogs` already
+gathers logs across the active profiles into `<workload>-logs.txt`.
+
+### `collectMetadata` without a window (`init/post.ts:106-147`)
+
+On a cluster failure `main` exits before `waitForWorkloads`, so `start`/`finish`
+are unset. Today `new Date('')` yields `Invalid Date` and `duration_ms: NaN`.
+Guard: when `start`/`finish` are absent, omit them (or write `null`) and omit
+`duration_ms`. `failed:'cluster'` is still written.
+
+### Cluster failure is unconditional (no code change, documented + preserved)
+
+`database-readiness` (`restart: no`) runs on every `up`, and `workload-current`
+depends on it via `service_completed_successfully`
+(`deploy/compose.yml:287-289`). So `docker compose up --detach` blocks on
+readiness and exits non-zero if it fails; the retry loop
+(`init/main.ts:80-108`) catches it and throws after 3 attempts → `main` catch
+sets `failed='cluster'` + `exit(1)`. This path runs **before** `waitForWorkloads`
+and is therefore independent of `fail_on_workload_error`. The refactor must
+preserve it.
+
+## Behavior matrix
+
+| Failure | Fails run via | Depends on `fail_on_workload_error`? | `post` artifacts |
+|---|---|---|---|
+| Cluster did not start | `deployInfra` throw → `failed='cluster'` → `exit 1` | **No** — always | cluster/init logs + metadata (no window); summary points to logs artifact |
+| Workload crashed, fail mode | `waitForWorkloads` throw → `failed='workload'` → `exit 1` | Yes (only when `true`) | logs + metadata + metrics/alerts (if Prometheus present); summary points to logs artifact |
+| Workload crashed, default | not failed (`warning`) | Yes (`false` → continue) | full set + report built |
+| A component disabled (e.g. telemetry), success | not failed | n/a | every available artifact; empty file for the absent source |
+| Normal success | not failed | n/a | full set + report built |
+
+## Files touched
+
+- `init/action.yml` — add `fail_on_workload_error` input.
+- `init/main.ts` — `allSettled` + fail-mode throw + save `finish` before throw
+  in `waitForWorkloads`. (No new state.)
+- `init/post.ts` — error boundary + guaranteed teardown; discovery-gated
+  metrics/alerts (skip when no Prometheus IP, drop the `http://prometheus:9090`
+  fallback); `collectAlerts` guard; `writeFailedSummary` → failure-typed heading
+  + pointer to the logs artifact (no inlined logs); `collectMetadata` without
+  window.
+- `README.md`, `AGENTS.md` — document the new input and the main↔post contract.
+- `dist/` — rebuilt via `bun run bundle`, force-added (`git add -f dist`).
+
+## Testing
+
+The project tests via E2E in real GitHub Actions workflows. Unit tests are
+reserved for non-trivial pure functions (e.g. `parseAlertsFromRange` in
+`init/lib/alerts.test.ts`, `getComposeProfiles` in `init/lib/docker.test.ts`).
+
+The decisions added here are trivial boolean guards — the fail-fast check
+(`failFast && failures.length > 0` in `waitForWorkloads`) and the Prometheus
+availability check (`!prometheusIp || !start || !finish` in `collectMetrics`/
+`collectAlerts`). They are inlined at their call sites, not extracted into a
+module or unit-tested. Correctness is covered by `bun run bundle` (transpile),
+the existing suite, and E2E runs of the scenarios in the behavior matrix.
+
+## Rollout
+
+- Default `false` keeps every existing SLO run unchanged.
+- A topics smoke test opts in with `fail_on_workload_error: true`. "No metrics,
+  no report" is not produced by this flag — it falls out of orthogonal choices:
+  metrics are absent because telemetry is disabled
+  (`disable_compose_profiles: telemetry,chaos`), and the report is gated off at
+  the workflow level.
+
+### Controlling the report on failure (orchestration, no input)
+
+Same workflow, two jobs (no fork support needed):
+
+```yaml
+report:
+  needs: test
+  # no `if:`            -> report skipped when `test` fails (default)
+  # if: ${{ !cancelled() }} -> always report (failure card on failure)
+  # if: ${{ failure() }}    -> report only on failure
+```
+
+Across workflows via `workflow_run` — required for PRs from forks, where the
+`pull_request` token is read-only and cannot post comments:
+
+```yaml
+# .github/workflows/slo-report.yml — runs in the base repo with write perms
+on:
+  workflow_run:
+    workflows: ["SLO Test"]   # = name: of the SLO workflow
+    types: [completed]
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    # decide whether to report on a failed init:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - uses: ydb-platform/ydb-slo-action/report@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_run_id: ${{ github.event.workflow_run.id }}   # the SLO run
+```
+
+`report` already supports this: it downloads artifacts from another run via
+`github_run_id` (`report/lib/artifacts.ts:33-40`) and reads the PR number from
+`meta.pull` (`report/main.ts:62`).
+
+## Future work (not in this spec)
+
+- An explicit, workload-independent readiness gate in `main` to catch a
+  "`compose up` succeeded but the cluster is actually broken" case independent of
+  the flag. Deferred because root-cause diagnosis of cluster start-up is a
+  separate effort.

--- a/init/action.yml
+++ b/init/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: "Duration of the workload in seconds."
     required: false
     default: "60"
+  fail_on_workload_error:
+    description: "Fail the whole run if any workload container exits non-zero or times out."
+    required: false
+    default: "false"
 
   # Workload: current
   workload_current_ref:

--- a/init/main.ts
+++ b/init/main.ts
@@ -2,7 +2,16 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { debug, error, getInput, info, saveState, setFailed, setOutput } from '@actions/core'
+import {
+	debug,
+	error,
+	getInput,
+	info,
+	saveState,
+	setFailed,
+	setOutput,
+	warning,
+} from '@actions/core'
 import { exec } from '@actions/exec'
 
 import { getComposeProfiles, getContainerIp, waitForContainerCompletion } from './lib/docker.js'
@@ -127,8 +136,11 @@ async function waitForWorkloads(): Promise<void> {
 	let workloadBaselineImage = getInput('workload_baseline_image') || ''
 	let workloadDuration = parseInt(getInput('workload_duration') || '60', 10)
 	let workloadTimeoutMs = (workloadDuration + 60) * 1000
+	let failFast = getInput('fail_on_workload_error') === 'true'
 
-	debug(`Workload configuration: duration=${workloadDuration}s, timeout=${workloadTimeoutMs}ms`)
+	debug(
+		`Workload configuration: duration=${workloadDuration}s, timeout=${workloadTimeoutMs}ms, failFast=${failFast}`
+	)
 
 	let workloadsToWait: { name: string; container: string }[] = []
 
@@ -139,29 +151,43 @@ async function waitForWorkloads(): Promise<void> {
 		workloadsToWait.push({ name: 'baseline', container: 'ydb-workload-baseline' })
 	}
 
+	let failures: string[] = []
+
 	if (workloadsToWait.length > 0) {
 		info(`Waiting for ${workloadsToWait.length} workload(s) to complete...`)
 		info(`  - ${workloadsToWait.map((w) => w.name).join(', ')}`)
 		info(`  - Timeout: ${workloadTimeoutMs / 1000}s (workload duration + 60s buffer)`)
 
-		try {
-			await Promise.all(
-				workloadsToWait.map((w) =>
-					waitForContainerCompletion({
-						container: w.container,
-						timeoutMs: workloadTimeoutMs,
-					})
-				)
+		// allSettled: in the default (tolerant) mode we wait for the full window of
+		// every workload instead of bailing on the first failure.
+		let results = await Promise.allSettled(
+			workloadsToWait.map((w) =>
+				waitForContainerCompletion({ container: w.container, timeoutMs: workloadTimeoutMs })
 			)
+		)
+
+		results.forEach((result, i) => {
+			if (result.status === 'rejected') {
+				let name = workloadsToWait[i].name
+				failures.push(`${name}: ${result.reason}`)
+				warning(`Workload '${name}' failed: ${result.reason}`)
+			}
+		})
+
+		if (failures.length === 0) {
 			info('All workloads completed successfully')
-		} catch (err) {
-			error(`Workload failed: ${err}`)
 		}
 	}
 
+	// Always record the window BEFORE any throw, so post has a valid window for
+	// diagnostic metrics even on a fail-mode crash.
 	let finish = new Date()
 	saveState('finish', finish.toISOString())
 	info(`Workloads finished at ${finish}`)
+
+	if (failFast && failures.length > 0) {
+		throw new Error(`Workload(s) failed: ${failures.join('; ')}`)
+	}
 }
 
 await main()

--- a/init/post.ts
+++ b/init/post.ts
@@ -2,7 +2,7 @@ import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { debug, getInput, getState, info, summary } from '@actions/core'
+import { debug, getInput, getState, info, summary, warning } from '@actions/core'
 import { exec } from '@actions/exec'
 
 import { analyzeWorkload } from '../shared/analysis.js'
@@ -25,38 +25,87 @@ async function post() {
 	let metricsPath = path.join(cwd, `${workload}-metrics.jsonl`)
 	let metadataPath = path.join(cwd, `${workload}-metadata.json`)
 
-	let logsContent = await collectLogs()
-	await fs.writeFile(logsPath, logsContent, { encoding: 'utf-8' })
+	let metricsContent = ''
+	let extraArtifactPaths: string[] = []
 
-	let alertsContent = await collectAlerts()
-	await fs.writeFile(alertsPath, alertsContent, { encoding: 'utf-8' })
+	try {
+		// Per-artifact best-effort: an unavailable source yields an empty file,
+		// never a thrown error and never a skipped sibling artifact.
+		await persist(logsPath, collectLogs)
+		await persist(alertsPath, collectAlerts)
+		metricsContent = await persist(metricsPath, collectMetrics)
+		await persist(metadataPath, collectMetadata)
+	} finally {
+		await teardown(cwd)
+	}
 
-	let metricsContent = await collectMetrics()
-	await fs.writeFile(metricsPath, metricsContent, { encoding: 'utf-8' })
+	try {
+		extraArtifactPaths = await collectExtraArtifacts(cwd)
+	} catch (err) {
+		warning(`Failed to collect extra artifacts: ${err}`)
+	}
 
-	let metadataContent = await collectMetadata()
-	await fs.writeFile(metadataPath, metadataContent, { encoding: 'utf-8' })
+	try {
+		await uploadArtifacts(
+			workload,
+			[logsPath, alertsPath, metricsPath, metadataPath, ...extraArtifactPaths],
+			cwd
+		)
+	} catch (err) {
+		warning(`Artifact upload failed: ${err}`)
+	}
 
-	let profiles = await getComposeProfiles(cwd)
-	await exec(`docker`, [`compose`, `-f`, `compose.yml`, `down`], {
-		cwd: path.resolve(process.env['GITHUB_ACTION_PATH'], 'deploy'),
-		env: {
-			...process.env,
-			COMPOSE_PROFILES: profiles.join(','),
-		},
-	})
+	try {
+		if (getState('failed')) {
+			await writeFailedSummary()
+		} else {
+			await writeWorkloadSummary(metricsContent)
+		}
+	} catch (err) {
+		warning(`Writing job summary failed: ${err}`)
+	}
+}
 
-	let extraArtifactPaths = await collectExtraArtifacts(cwd)
-	await uploadArtifacts(
-		workload,
-		[logsPath, alertsPath, metricsPath, metadataPath, ...extraArtifactPaths],
-		cwd,
-	)
+/**
+ * Collect best-effort and write to disk. Never throws. A collector that cannot
+ * reach its source returns an empty string, so the file is always written.
+ */
+async function persist(filePath: string, collect: () => Promise<string>): Promise<string> {
+	let content = ''
 
-	if (getState('failed')) {
-		await writeFailedSummary()
-	} else {
-		await writeWorkloadSummary(metricsContent)
+	try {
+		content = await collect()
+	} catch (err) {
+		warning(`Failed to collect ${path.basename(filePath)}: ${err}`)
+	}
+
+	try {
+		await fs.writeFile(filePath, content, { encoding: 'utf-8' })
+	} catch (err) {
+		warning(`Failed to write ${path.basename(filePath)}: ${err}`)
+	}
+
+	return content
+}
+
+/** Tear down the compose project. Never throws — cleanup must always run. */
+async function teardown(cwd: string): Promise<void> {
+	info('Tearing down infrastructure...')
+
+	try {
+		let profiles = await getComposeProfiles(
+			cwd,
+			getInput('disable_compose_profiles').split(',')
+		)
+		await exec(`docker`, [`compose`, `-f`, `compose.yml`, `down`], {
+			cwd: path.resolve(process.env['GITHUB_ACTION_PATH'], 'deploy'),
+			env: {
+				...process.env,
+				COMPOSE_PROFILES: profiles.join(','),
+			},
+		})
+	} catch (err) {
+		warning(`Teardown (docker compose down) failed: ${err}`)
 	}
 }
 
@@ -72,41 +121,55 @@ async function collectLogs(): Promise<string> {
 async function collectAlerts(): Promise<string> {
 	info('Collecting alerts from Prometheus...')
 
-	if (!getState('start') || !getState('finish')) {
+	let start = getState('start')
+	let finish = getState('finish')
+	let prometheusIp = await getContainerIp('ydb-prometheus')
+
+	if (!prometheusIp || !start || !finish) {
+		info('Skipping alerts: Prometheus is not available or no time window exists')
 		return ''
 	}
 
-	let start = new Date(getState('start'))
-	let finish = getState('finish') ? new Date(getState('finish')) : new Date()
-
-	let prometheusIp = await getContainerIp('ydb-prometheus')
-	let prometheusUrl = prometheusIp ? `http://${prometheusIp}:9090` : 'http://prometheus:9090'
+	let prometheusUrl = `http://${prometheusIp}:9090`
 	debug(`Prometheus URL for alerts: ${prometheusUrl}`)
 
-	let alerts = await collectAlertsFromPrometheus(prometheusUrl, start, finish)
-	let content = alerts.map((a) => JSON.stringify(a)).join('\n')
-	return content
+	try {
+		let alerts = await collectAlertsFromPrometheus(
+			prometheusUrl,
+			new Date(start),
+			new Date(finish)
+		)
+		return alerts.map((a) => JSON.stringify(a)).join('\n')
+	} catch (err) {
+		warning(`Failed to collect alerts: ${err}`)
+		return ''
+	}
 }
 
 async function collectMetrics(): Promise<string> {
 	info('Collecting metrics...')
 
-	if (!getState('start') || !getState('finish')) {
+	let start = getState('start')
+	let finish = getState('finish')
+	let prometheusIp = await getContainerIp('ydb-prometheus')
+
+	if (!prometheusIp || !start || !finish) {
+		info('Skipping metrics: Prometheus is not available or no time window exists')
 		return ''
 	}
 
-	let start = new Date(getState('start'))
-	let finish = getState('finish') ? new Date(getState('finish')) : new Date()
-
-	let prometheusIp = await getContainerIp('ydb-prometheus')
-	let prometheusUrl = prometheusIp ? `http://${prometheusIp}:9090` : 'http://prometheus:9090'
+	let prometheusUrl = `http://${prometheusIp}:9090`
 	debug(`Prometheus URL: ${prometheusUrl}`)
 
 	let config = await loadMetricConfig(getInput('metrics_yaml'), getInput('metrics_yaml_path'))
-	let metrics = await collectMetricsFromPrometheus(prometheusUrl, start, finish, config)
-	let content = metrics.map((m) => JSON.stringify(m)).join('\n')
+	let metrics = await collectMetricsFromPrometheus(
+		prometheusUrl,
+		new Date(start),
+		new Date(finish),
+		config
+	)
 
-	return content
+	return metrics.map((m) => JSON.stringify(m)).join('\n')
 }
 
 async function collectMetadata(): Promise<string> {
@@ -114,10 +177,12 @@ async function collectMetadata(): Promise<string> {
 
 	let pull = getState('pull')
 	let commit = getState('commit')
-	let start = new Date(getState('start'))
-	let finish = getState('finish') ? new Date(getState('finish')) : new Date()
 	let failed = getState('failed') as '' | 'cluster' | 'workload'
-	let duration = finish.getTime() - start.getTime()
+
+	let startState = getState('start')
+	let finishState = getState('finish')
+	let start = startState ? new Date(startState) : undefined
+	let finish = finishState ? new Date(finishState) : undefined
 
 	let workload = getState('workload')
 	let workload_current_ref = getInput('workload_current_ref')
@@ -142,11 +207,11 @@ async function collectMetadata(): Promise<string> {
 		workload,
 		workload_current_ref,
 		workload_baseline_ref,
-		start_time: start.toISOString(),
-		start_epoch_ms: start.getTime(),
-		finish_time: finish.toISOString(),
-		finish_epoch_ms: finish.getTime(),
-		duration_ms: duration,
+		start_time: start?.toISOString(),
+		start_epoch_ms: start?.getTime(),
+		finish_time: finish?.toISOString(),
+		finish_epoch_ms: finish?.getTime(),
+		duration_ms: start && finish ? finish.getTime() - start.getTime() : undefined,
 	})
 
 	return content
@@ -170,13 +235,14 @@ async function writeWorkloadSummary(metricsContent: string) {
 }
 
 async function writeFailedSummary() {
-	let cwd = getState('cwd')
 	let workload = getState('workload')
+	let failed = getState('failed') as '' | 'cluster' | 'workload'
 
-	summary.addHeading(`Failed ${workload}.`)
-
-	let workloadLogs = await collectComposeLogs(cwd, ['workload-current', 'workload-baseline'])
-	summary.addCodeBlock(workloadLogs)
+	summary.addHeading(`Failed ${workload} (${failed || 'unknown'}).`)
+	summary.addRaw(
+		`See the \`${workload}-logs.txt\` artifact attached to this run for full logs.`,
+		true
+	)
 
 	await summary.write()
 }

--- a/shared/metadata.ts
+++ b/shared/metadata.ts
@@ -7,11 +7,11 @@ export interface TestMetadata {
 	run_id?: string
 	run_url?: string
 	workload: string
-	start_time: string
-	start_epoch_ms: number
-	finish_time: string
-	finish_epoch_ms: number
-	duration_ms: number
+	start_time?: string
+	start_epoch_ms?: number
+	finish_time?: string
+	finish_epoch_ms?: number
+	duration_ms?: number
 	workload_current_ref?: string
 	workload_baseline_ref?: string
 }


### PR DESCRIPTION
## Summary

- **Opt-in `fail_on_workload_error` input** (default `false`) on `init`. When `true`, a workload container that exits non-zero **or times out** fails the whole run. Default behavior is unchanged: failures are tolerated (warn + continue), metrics and report still produced. `waitForWorkloads` now uses `Promise.allSettled` (waits for the full window of every workload) and saves `finish` **before** any throw so `post` keeps a window for diagnostic metrics.
- **Resilient `post` lifecycle** — resilience is structural, not telemetry-specific:
  - per-collector best-effort (a missing source yields an empty artifact, never a thrown error);
  - top-level error boundary with **guaranteed `docker compose down`** via `finally`; upload + summary guarded; `post` never calls `setFailed`;
  - metrics/alerts gated on Prometheus **discovery** (`getContainerIp`), dropping the broken `http://prometheus:9090` fallback and fixing the `collectAlerts` crash when telemetry is disabled;
  - `collectMetadata` tolerates a missing window (no more `NaN`/`Invalid Date`); `shared/metadata.ts` timestamp fields are now optional;
  - `writeFailedSummary` names the failure type and **points to the `<workload>-logs.txt` artifact** instead of inlining logs.
- **Cluster-deploy failure still fails the run unconditionally**, independent of the flag.
- **Reporting on failure stays workflow orchestration** (`needs:`/`if:`, or `workflow_run.conclusion` for PRs from forks) — documented in the README, no new input.
- Preserves the pre-existing `.slo/extra` user-artifacts feature.

## Design

`docs/superpowers/specs/2026-06-18-fail-on-workload-error-design.md`

## Test plan

- [x] `bun test` — 57/57 pass. The two new guards are trivial booleans, inlined at their call sites (no unit test, per the repo's E2E + non-trivial-pure-function convention).
- [x] `tsc --noEmit` clean · `oxlint` clean · `bun run bundle` rebuilt with no `dist` drift
- [ ] E2E smoke test: `fail_on_workload_error: true` + `disable_compose_profiles: telemetry,chaos` → non-zero workload exit fails the run; no metrics/report; logs artifact present
- [ ] E2E default run unchanged: metrics + report produced
- [ ] E2E telemetry disabled: `post` does not crash, artifacts still uploaded
- [ ] E2E cluster-deploy failure: run fails, logs artifact present, infra torn down