### PR TITLE
Fix YDB cluster bootstrap flakiness + diagnostic visibility

### DIFF
--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -60,6 +60,7 @@ services:
     environment:
       - YDB_TENANT=/Root/testdb
       - YDB_ENDPOINT=grpc://ydb:2136
+      - YDB_START_DELAY=0
     networks:
       slo:
         ipv4_address: 172.28.0.11
@@ -80,6 +81,7 @@ services:
     environment:
       - YDB_TENANT=/Root/testdb
       - YDB_ENDPOINT=grpc://ydb:2136
+      - YDB_START_DELAY=4
     networks:
       slo:
         ipv4_address: 172.28.0.12
@@ -102,6 +104,7 @@ services:
     environment:
       - YDB_TENANT=/Root/testdb
       - YDB_ENDPOINT=grpc://ydb:2136
+      - YDB_START_DELAY=8
     networks:
       slo:
         ipv4_address: 172.28.0.13
@@ -124,6 +127,7 @@ services:
     environment:
       - YDB_TENANT=/Root/testdb
       - YDB_ENDPOINT=grpc://ydb:2136
+      - YDB_START_DELAY=12
     networks:
       slo:
         ipv4_address: 172.28.0.14
@@ -146,6 +150,7 @@ services:
     environment:
       - YDB_TENANT=/Root/testdb
       - YDB_ENDPOINT=grpc://ydb:2136
+      - YDB_START_DELAY=16
     networks:
       slo:
         ipv4_address: 172.28.0.15

--- a/deploy/ydb/rootfs/opt/ydb.tech/scripts/ydbd/check-readiness.sh
+++ b/deploy/ydb/rootfs/opt/ydb.tech/scripts/ydbd/check-readiness.sh
@@ -23,10 +23,12 @@ check_cluster_health() {
 
     local max_attempts=30
     local attempt=0
+    local output
 
     while [[ $attempt -lt $max_attempts ]]; do
         # Note: monitoring healthcheck doesn't need --database parameter
-        if timeout "${YDB_READINESS_TIMEOUT}" ydb --endpoint "${YDB_STORAGE_ENDPOINT}" monitoring healthcheck 2>/dev/null | grep -q "GOOD"; then
+        output=$(timeout "${YDB_READINESS_TIMEOUT}" ydb --endpoint "${YDB_STORAGE_ENDPOINT}" monitoring healthcheck 2>&1 || true)
+        if grep -q "GOOD" <<<"$output"; then
             log "Cluster health check passed"
             return 0
         fi
@@ -37,6 +39,8 @@ check_cluster_health() {
     done
 
     log "ERROR: Cluster health check failed after $max_attempts attempts"
+    log "Last healthcheck output (why the cluster self-check isn't GOOD):"
+    echo "$output" >&2
     return 1
 }
 

--- a/deploy/ydb/rootfs/opt/ydb.tech/scripts/ydbd/entrypoint.sh
+++ b/deploy/ydb/rootfs/opt/ydb.tech/scripts/ydbd/entrypoint.sh
@@ -41,6 +41,17 @@ perform_database_creation() {
 }
 
 start_ydb_node() {
+    if [[ -n "$YDB_START_DELAY" ]]; then
+        # Dynamic nodes all depend only on storage-1 and race to register with
+        # it the moment it's healthy. storage-1's BlobStorage session setup
+        # has a hardcoded 5s timeout (ProxyEstablishSessionsTimeout in
+        # ydb/core/blobstorage/dsproxy/dsproxy.h) - a burst of simultaneous
+        # registrations can blow past that under load, so nodes stagger their
+        # start instead of all hitting storage-1 at once.
+        log "Delaying node start by ${YDB_START_DELAY}s to stagger registration with storage"
+        sleep "$YDB_START_DELAY"
+    fi
+
     local grpc_port="${YDB_GRPC_PORT:-2136}"
     local mon_port="${YDB_MON_PORT:-8765}"
     local ic_port="${YDB_IC_PORT:-19001}"

--- a/deploy/ydb/rootfs/opt/ydb.tech/scripts/ydbd/entrypoint.sh
+++ b/deploy/ydb/rootfs/opt/ydb.tech/scripts/ydbd/entrypoint.sh
@@ -23,11 +23,21 @@ perform_cluster_bootstrap() {
 perform_database_creation() {
     local database_path="${YDB_TENANT:-/Root/testdb}"
     log "Creating database '$database_path' with endpoint: $YDB_ENDPOINT"
-    if ydbd -s "$YDB_ENDPOINT" admin database "$database_path" create ssd:1 2>&1 | grep -q "ALREADY_EXISTS"; then
-        log "Database '$database_path' already exists"
-    else
-        log "Database creation completed with exit code: $?"
+
+    local output
+    if output=$(ydbd -s "$YDB_ENDPOINT" admin database "$database_path" create ssd:1 2>&1); then
+        log "Database '$database_path' created"
+        return 0
     fi
+
+    if grep -q "ALREADY_EXISTS" <<<"$output"; then
+        log "Database '$database_path' already exists"
+        return 0
+    fi
+
+    log "ERROR: Database creation failed:"
+    echo "$output" >&2
+    return 1
 }
 
 start_ydb_node() {

--- a/deploy/ydb/rootfs/opt/ydb.tech/ydbd/cfg/config.yaml
+++ b/deploy/ydb/rootfs/opt/ydb.tech/ydbd/cfg/config.yaml
@@ -25,14 +25,14 @@ config:
     enable_public_api_external_blobs: false
     enable_scheme_transactions_at_scheme_shard: true
 
+  # A single drive is enough: erasure is none (no redundancy across disks
+  # to benefit from), and a second/third SectorMap PDisk is one more thing
+  # that can fail to initialize (observed: "Can't open file SectorMap:2:64"
+  # -> PDisk StateError -> disintegrated group) for no upside here.
   host_configs:
     - host_config_id: 1
       drive:
         - path: SectorMap:1:64
-          type: SSD
-        - path: SectorMap:2:64
-          type: SSD
-        - path: SectorMap:3:64
           type: SSD
 
   hosts:


### PR DESCRIPTION
## Summary
Investigated intermittent "Failed to start YDB cluster" failures across SDK repos (python-sdk, go-sdk, etc.). Two categories of fix:

**Diagnostics (were masking the real cause):**
- `check-readiness.sh` piped `ydb monitoring healthcheck` into `grep -q "GOOD"` with output sent to `/dev/null` - a failing self-check never showed *why*. Now logs the last healthcheck output when the check ultimately fails.
- `entrypoint.sh`'s `perform_database_creation` checked `$?` after the if-statement had already evaluated (the if-test's own exit status, not `ydbd`'s), so it silently reported success even when database creation genuinely failed. Now captures the real exit code/output, treats `ALREADY_EXISTS` as the expected idempotent case, and fails loudly otherwise.

**Root causes (found via CI artifact logs showing `BS_PROXY_DISCOVER ERROR ... Group disintegrated` / `PDisk ... StateError`):**
- `config.yaml` declared 3 SectorMap PDisks per host, but `erasure: none` means no redundancy benefit from the extra disks - just extra surface area for one to fail to initialize (observed: `Can't open file "SectorMap:2:64"`). Down to 1 disk, matching YDB's own `local-ydb` reference config.
- All 5 `database-N` nodes raced to register with `storage-1` simultaneously (identical `depends_on`, no ordering). `storage-1`'s BlobStorage session establishment has a hardcoded, non-configurable 5s timeout (`ProxyEstablishSessionsTimeout` in `ydb/core/blobstorage/dsproxy/dsproxy.h`) that a burst of concurrent registrations could exceed. Dynamic nodes now stagger their start via `YDB_START_DELAY` (0/4/8/12/16s).

## Test plan
- [x] Local `docker compose up` verified cluster-readiness passes cleanly with the staggered start
- [ ] Could not reproduce the original flaky failure locally (artificial CPU-constraint testing didn't reproduce it either way - see PR discussion), so real validation is watching CI runs on this branch/PR across the affected SDK repos