### PR TITLE
🐛 Stabilize chaos alert identity

### DIFF
--- a/deploy/chaos/otel-metric.test.ts
+++ b/deploy/chaos/otel-metric.test.ts
@@ -1,0 +1,55 @@
+import * as assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import * as path from 'node:path'
+
+import { test } from 'bun:test'
+
+let scriptPath = path.join(import.meta.dir, 'rootfs/opt/ydb.tech/scripts/chaos/otel_metric.py')
+let probe = [
+	'import importlib.util',
+	'import json',
+	'import sys',
+	'spec = importlib.util.spec_from_file_location("otel_metric", sys.argv[1])',
+	'module = importlib.util.module_from_spec(spec)',
+	'spec.loader.exec_module(module)',
+	'print(json.dumps(module.get_resource_attributes()))',
+].join('\n')
+
+function readResourceAttributes(overrides: Record<string, string> = {}): Record<string, string> {
+	let env = {
+		...process.env,
+		OTEL_SERVICE_NAME: 'chaos-test',
+		PYTHONDONTWRITEBYTECODE: '1',
+	}
+	delete env.OTEL_SERVICE_INSTANCE_ID
+	Object.assign(env, overrides)
+
+	let result = spawnSync('python3', ['-c', probe, scriptPath], {
+		env,
+		encoding: 'utf8',
+	})
+
+	assert.equal(result.status, 0, result.stderr)
+	return JSON.parse(result.stdout)
+}
+
+test('chaos OTLP resource keeps one instance id across exporter processes', () => {
+	let first = readResourceAttributes()
+	let second = readResourceAttributes()
+
+	assert.equal(first['service.name'], 'chaos-test')
+	assert.ok(first['service.instance.id'])
+	assert.equal(second['service.instance.id'], first['service.instance.id'])
+})
+
+test('chaos OTLP resource accepts an explicit instance id', () => {
+	let attributes = readResourceAttributes({ OTEL_SERVICE_INSTANCE_ID: 'chaos-instance' })
+
+	assert.equal(attributes['service.instance.id'], 'chaos-instance')
+})
+
+test('chaos OTLP resource falls back from an empty instance id', () => {
+	let attributes = readResourceAttributes({ OTEL_SERVICE_INSTANCE_ID: '' })
+
+	assert.ok(attributes['service.instance.id'])
+})

--- a/deploy/chaos/rootfs/opt/ydb.tech/scripts/chaos/otel_metric.py
+++ b/deploy/chaos/rootfs/opt/ydb.tech/scripts/chaos/otel_metric.py
@@ -1,16 +1,28 @@
 # pyright: reportMissingImports=false
 
 import os
+import socket
 import sys
 
-from opentelemetry import metrics
-from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
-from opentelemetry.sdk.metrics import MeterProvider
-from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
-from opentelemetry.sdk.resources import Resource
+
+def get_resource_attributes():
+    service_name = os.environ.get("OTEL_SERVICE_NAME", "unknown-service")
+    service_instance_id = os.environ.get("OTEL_SERVICE_INSTANCE_ID") or socket.gethostname()
+    return {
+        "service.name": service_name,
+        "service.instance.id": service_instance_id,
+    }
 
 
 def main():
+    from opentelemetry import metrics
+    from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
+        OTLPMetricExporter,
+    )
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+    from opentelemetry.sdk.resources import Resource
+
     if len(sys.argv) < 4:
         print("Usage: otel_metric.py <type> <name> <value> [key=value ...]")
         sys.exit(1)
@@ -33,9 +45,7 @@ def main():
     endpoint = os.environ.get(
         "OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318/v1/metrics"
     )
-    service_name = os.environ.get("OTEL_SERVICE_NAME", "unknown-service")
-
-    resource = Resource.create({"service.name": service_name})
+    resource = Resource.create(get_resource_attributes())
 
     # We use HTTP exporter
     exporter = OTLPMetricExporter(endpoint=endpoint)


### PR DESCRIPTION
## What changes

- Keep one OpenTelemetry `service.instance.id` across all one-shot chaos metric exporter processes in a container.
- Cover the default container identity, an explicit override, and an empty override with regression tests.

## Why

`chaos_inject` and `chaos_recover` previously exported from separate OpenTelemetry process identities. Prometheus therefore stored `1` and `0` in different series, leaving every recovered fault firing until the five-minute staleness window and rendering overlapping chaos intervals in SLO reports.

## Validation

- `bun test`: 65 passed.
- Built the chaos image locally.
- Verified `chaos_active: 1 -> 0` through two separate exporter processes against Prometheus; both samples used one series and `ALERTS{alertstate="firing"}` disappeared after recovery.
- [JavaScript SDK matrix run 31707979832](https://github.com/ydb-platform/ydb-js-sdk/actions/runs/31707979832): all regular and 2DC jobs passed with the fix pinned by commit SHA.
- The live artifacts use one instance per chaos container, contain no 285-second stale intervals, and both 2DC jobs completed all five bridge scenarios.
